### PR TITLE
adds sourceMap to compiler default command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Just add a `.ts` file in your `app/assets/typescripts` directory and include it 
 Configurations:
 
 ```
-# Its defaults are `--target ES5 --module system --moduleResolution node --experimentalDecorators --emitDecoratorMetadata`.
+# Its defaults are `--target ES5 --module system --moduleResolution node --sourceMap --experimentalDecorators --emitDecoratorMetadata`.
 
 Typescript::Rails::Compiler.default_options = [ ... ]
 ```

--- a/lib/typescript/rails/compiler.rb
+++ b/lib/typescript/rails/compiler.rb
@@ -14,7 +14,7 @@ module Typescript::Rails::Compiler
       relative_path = ts_path.gsub(path, '')
       js_path = File.join(Rails.root, 'tmp', 'typescript_rails', relative_path).gsub('.ts', '.js')
 
-      command = "#{File.join(Rails.root, 'node_modules', 'typescript', 'bin', 'tsc')} --target ES5 --module system --moduleResolution node --emitDecoratorMetadata --experimentalDecorators --rootDir #{path} --outFile #{js_path} #{ts_path}"
+      command = "#{File.join(Rails.root, 'node_modules', 'typescript', 'bin', 'tsc')} --target ES5 --module system --moduleResolution node --sourceMap --emitDecoratorMetadata --experimentalDecorators --rootDir #{path} --outFile #{js_path} #{ts_path}"
       Rails.logger.info "Typescript::Rails::Compiler #{command}"
       stdout, stderr, exit_status = Open3.capture3(command)
       if exit_status == 0


### PR DESCRIPTION
This PR adds the creation of source maps to the compiler default options. This enables easier debugging of typescript files, as breakpoints can be set in the typescript files rather than the outputted js files.
